### PR TITLE
use stringify options to have a more readable manifest

### DIFF
--- a/src/digestifyMarkdownAssets.js
+++ b/src/digestifyMarkdownAssets.js
@@ -41,7 +41,7 @@ const writeManifest = manifest =>
   new Promise((resolve, reject) =>
     fs.writeFile(
       'manifest.json',
-      JSON.stringify(manifest),
+      JSON.stringify(manifest, null, 2),
       error => (error ? reject(`Can not write the manifest.json : ${error}`) : resolve(manifest))
     )
   );


### PR DESCRIPTION
Just a simple change but it will add line returns to the manifest and use 2 spaces for indentation.

resolves #2