### PR TITLE
Add a positional arg to ignore some markdown files

### DIFF
--- a/__tests__/fixtures/.gitignore
+++ b/__tests__/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/__tests__/fixtures/node_modules/a-file-that-should-not-be-in-the-final-result.txt
+++ b/__tests__/fixtures/node_modules/a-file-that-should-not-be-in-the-final-result.txt
@@ -1,0 +1,1 @@
+Hey, I am inside a node_modules directory, therefore, I should be ignored.

--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -24,7 +24,7 @@ module.exports = {
     });
 
     yargs.positional('ignore', {
-      describe: 'Glob pattern matchingfiles that will not be updated',
+      describe: 'Glob pattern matching files that will not be updated (node_modules will always be ignored)',
       default: null
     });
 

--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -23,6 +23,11 @@ module.exports = {
       default: true
     });
 
+    yargs.positional('ignore', {
+      describe: 'Glob pattern matchingfiles that will not be updated',
+      default: null
+    });
+
     yargs.positional('cdn-url', {
       describe: 'CDN URL used in the Markdown to get the assets'
     });

--- a/src/digestifyMarkdownAssets.js
+++ b/src/digestifyMarkdownAssets.js
@@ -18,7 +18,7 @@ const uploadAssets = (bucket, manifest) => {
   return Promise.all(Object.keys(manifest).map(uploadAsset));
 };
 
-const updateMarkdowns = (CDN, manifest) => {
+const updateMarkdowns = (CDN, ignorePattern, manifest) => {
   const updateMarkdown = markdownPath =>
     readFile(markdownPath, 'utf8').then(content => {
       const newContent = markdown.updateLinks({ path: markdownPath, content: content }, manifest, CDN);
@@ -32,7 +32,7 @@ const updateMarkdowns = (CDN, manifest) => {
       );
     });
 
-  return glob('**/*.md', { nocase: true })
+  return glob('**/*.md', { nocase: true, ignore: ignorePattern ? ignorePattern : undefined })
     .then(paths => Promise.all(paths.map(updateMarkdown)))
     .then(() => manifest);
 };
@@ -54,7 +54,7 @@ const digestifyMarkdownAssets = commandLineArguments => {
   glob(pattern, { nocase: true })
     .then(manifest.fromPaths)
     .then(writeManifest)
-    .then(manifest => updateMarkdowns(commandLineArguments.cdnUrl, manifest))
+    .then(manifest => updateMarkdowns(commandLineArguments.cdnUrl, commandLineArguments.ignore, manifest))
     .then(manifest => uploadAssets(commandLineArguments.bucket, manifest))
     .then(() => console.log('Manifest generated, Markdown updated, Assets uploaded.'))
     .catch(console.error);


### PR DESCRIPTION
With that change, we can now use `--ignore '**/DONTTOUCHME.md'` to a compile call to let these markdown be untouched.